### PR TITLE
fix: resolve repository name for linked repositories in actions permi…

### DIFF
--- a/modules/repository/actions.tf
+++ b/modules/repository/actions.tf
@@ -10,5 +10,11 @@ resource "github_actions_repository_permissions" "actions" {
       verified_allowed     = var.allowed_github_actions_config.verified_allowed
     }
   }
-  repository = github_repository.repository[0].name
+  # local.repository_name resolves for both created and linked (create_repository = false) repositories
+  repository = local.repository_name
+
+  depends_on = [
+    github_repository.repository,
+    data.github_repository.existing_repo
+  ]
 }

--- a/tests/basic-link/1-example.tf
+++ b/tests/basic-link/1-example.tf
@@ -1,10 +1,15 @@
 module "this" {
   source = "../../"
 
-  repositories = [{
-    name              = "terraform-null-empty"
-    default_branch    = "main"
+  # linking an existing repository is a catalog-wide setting, the repositories
+  # entry schema only accepts name/description/topics/pages
+  defaults = {
     create_repository = false
+    default_branch    = "main"
+  }
+
+  repositories = [{
+    name = "terraform-null-empty"
     }
   ]
 }


### PR DESCRIPTION
…ssions

github_actions_repository_permissions referenced github_repository.repository[0] directly, which is an empty tuple when create_repository is false, so linking an existing repository failed with "Invalid index" during plan. Use the local.repository_name value that already resolves both the created resource and the existing_repo data source, as the rest of the module does.

Also update tests/basic-link to the current variable schema: create_repository and default_branch are defaults-level settings, the repositories entry object only accepts name/description/topics/pages.